### PR TITLE
Support aws provider 3x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform/
+*.idea

--- a/aws_cloudtrail.tf
+++ b/aws_cloudtrail.tf
@@ -43,7 +43,7 @@ resource "aws_cloudtrail" "ct" {
   enable_log_file_validation    = var.aws_flags.enable_log_file_validation
   include_global_service_events = var.aws_flags.include_global_service_events
   is_multi_region_trail         = var.aws_flags.is_multi_region_trail
-  cloud_watch_logs_group_arn    = "${replace(aws_cloudwatch_log_group.example.arn, "/:\\*$/", "")}:*"
+  cloud_watch_logs_group_arn    = "${replace(aws_cloudwatch_log_group.ct.arn, "/:\\*$/", "")}:*"
   cloud_watch_logs_role_arn     = aws_iam_role.ct.arn
   sns_topic_name                = aws_sns_topic.sns.arn
   depends_on                    = [aws_s3_bucket_policy.bucket]

--- a/aws_cloudtrail.tf
+++ b/aws_cloudtrail.tf
@@ -43,7 +43,7 @@ resource "aws_cloudtrail" "ct" {
   enable_log_file_validation    = var.aws_flags.enable_log_file_validation
   include_global_service_events = var.aws_flags.include_global_service_events
   is_multi_region_trail         = var.aws_flags.is_multi_region_trail
-  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.ct.arn
+  cloud_watch_logs_group_arn    = "${replace(aws_cloudwatch_log_group.example.arn, "/:\\*$/", "")}:*"
   cloud_watch_logs_role_arn     = aws_iam_role.ct.arn
   sns_topic_name                = aws_sns_topic.sns.arn
   depends_on                    = [aws_s3_bucket_policy.bucket]

--- a/module_provider_constraints.tf
+++ b/module_provider_constraints.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_providers {
+    aws       = ">= 2.0"
+    template  = "~> 2.1"
+  }
+}


### PR DESCRIPTION
Add real provider constraints, and change cloudtrail resource definition to handle changes in how the AWS provider outputs the CloudWatch Log Group ARN between provider 2.X and 3.X